### PR TITLE
feat: 공통컴포넌트 '다음으로' 버튼

### DIFF
--- a/components/common/NextButton.tsx
+++ b/components/common/NextButton.tsx
@@ -1,0 +1,34 @@
+import {Pressable, View, Text} from 'react-native';
+
+interface IProps {
+  content: string;
+  backgroundColor: string;
+  callbackFn: () => void;
+  disabled?: boolean;
+}
+const NextButton = ({
+  content,
+  backgroundColor,
+  callbackFn,
+  disabled = false,
+}: IProps) => {
+  return (
+    <View className="w-[320px] h-[52px]">
+      <Pressable
+        onPress={callbackFn}
+        disabled={disabled}
+        className={`flex-1 rounded-[12px] ${backgroundColor} ${
+          disabled ? 'bg-grey-20' : 'active:opacity-70'
+        } items-center justify-center`}>
+        <Text
+          className={`text-white text-label1-medium ${
+            disabled ? 'opacity-70' : ''
+          }`}>
+          {content}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};
+
+export default NextButton;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   // NOTE: Update this to include the paths to all of your component files.
-  content: ['./App.{js,jsx,ts,tsx}'],
+  content: [
+    './App.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './src/**/*.{js,jsx,ts,tsx}',
+  ],
   presets: [require('nativewind/preset')],
   theme: {
     extend: {
@@ -136,9 +140,9 @@ module.exports = {
         'grey-15': '#2E363A',
         'grey-10': '#1E2427',
         'grey-05': '#171B1C',
-        'background-normal': '##0E0E0E',
+        'background-normal': '#0E0E0E',
         'background-elevated': '#0E0E0E80',
-        'text-primary': '##FDFDFD',
+        'text-primary': '#FDFDFD',
         'text-secondary': '#999FA4',
       },
     },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3

## 📝작업 내용

> 공통컴포넌트중 '다음으로' 버튼을 구현했습니다.

### 스크린샷 (선택)

**active**
<img width="395" alt="image" src="https://github.com/user-attachments/assets/fce63082-ecda-4d92-82fc-ef8b990237ab" />

**deactivate**
<img width="413" alt="image" src="https://github.com/user-attachments/assets/88d44e0e-37fd-401f-bcfb-1c517220de5a" />


## 💬리뷰 요구사항(선택)

버튼안에 글자 - content
배경색 - backgroundColor
콜백함수 - callbackFn
비활성화 - disabled

4개인자를 props로 받도록 설정했습니다. disabled같은 경우엔 옵셔널로 비활성시킬때만 인자로 받도록 구현했습니다. 
(일반적으로 활성화 상황이라 판단)